### PR TITLE
Load onnxruntime wasm from CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dat.gui": "^0.7.9",
+        "onnxruntime-web": "^1.23.0",
         "postprocessing": "^7.0.0-alpha-1",
         "three": "^0.160.0"
       },
@@ -368,6 +369,79 @@
         "node": ">=12"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
     "node_modules/dat.gui": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
@@ -410,6 +484,12 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -423,6 +503,18 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -442,11 +534,37 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.23.0.tgz",
+      "integrity": "sha512-Auz8S9D7vpF8ok7fzTobvD1XdQDftRf/S7pHmjeCr3Xdymi4z1C7zx4vnT6nnUjbpelZdGwda0BmWHCCTMKUTg==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.23.0.tgz",
+      "integrity": "sha512-w0bvC2RwDxphOUFF8jFGZ/dYw+duaX20jM6V4BIZJPCfK4QuCpB/pVREV+hjYbT3x4hyfa2ZbTaWx4e1Vot0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.23.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.33",
@@ -487,6 +605,30 @@
         "three": ">= 0.160.0 < 0.161.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
@@ -516,6 +658,12 @@
       "version": "0.160.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
       "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "dat.gui": "^0.7.9",
+    "onnxruntime-web": "^1.23.0",
     "postprocessing": "^7.0.0-alpha-1",
     "three": "^0.160.0"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,13 @@
     <aside id="asteroidListPanel" class="asteroid-panel">
         <header class="asteroid-panel__header">Tracked Asteroids</header>
         <ul id="asteroidList" class="asteroid-panel__list"></ul>
+        <div class="asteroid-panel__actions">
+            <button id="generateAsteroidButton" class="asteroid-panel__button" type="button">
+                Generate Demo Asteroid
+            </button>
+            <p class="asteroid-panel__hint">Creates a synthetic asteroid and classifies it using the ONNX model.</p>
+            <p class="asteroid-panel__status" data-asteroid-generator-status hidden></p>
+        </div>
     </aside>
     <aside id="viewTargetPanel" class="view-panel">
         <header class="view-panel__header">View Targets</header>

--- a/src/main.js
+++ b/src/main.js
@@ -52,11 +52,12 @@ import {
   createImpactOverlayMesh,
   disposeObject
 } from './simulation/asteroids.js';
-import { propagateKepler } from './simulation/kepler.js';
+import { propagateKepler, createKeplerElements } from './simulation/kepler.js';
 import { orbitPositionToScene, estimateOrbitalVelocity } from './simulation/orbitUtils.js';
 import { updateEarthVelocity } from './simulation/referenceFrames.js';
-import { EARTH_RADIUS_SCENE_UNITS } from './simulation/scales.js';
+import { AU_TO_SCENE_UNITS, EARTH_RADIUS_SCENE_UNITS, FRAMES_PER_SIMULATION_DAY } from './simulation/scales.js';
 import { createImpactorManager } from './simulation/impactorManager.js';
+import { classifyAsteroid } from './model/neoClassifier.js';
 
 const cubeTextureLoader = new THREE.CubeTextureLoader();
 const textureLoader = new THREE.TextureLoader();
@@ -119,6 +120,8 @@ const impactMapStatusBaseText = impactMapStatusElement?.textContent ?? 'Awaiting
 const impactMapCaptionBaseText = impactMapCaptionElement?.textContent ?? '';
 const kineticMitigationButton = document.getElementById('kineticMitigationButton');
 const kineticMitigationStatus = document.querySelector('[data-kinetic-status]');
+const asteroidGeneratorButton = document.getElementById('generateAsteroidButton');
+const asteroidGeneratorStatusElement = document.querySelector('[data-asteroid-generator-status]');
 
 const ASTEROID_TYPES = {
   M: {
@@ -137,6 +140,184 @@ const ASTEROID_TYPES = {
     nominalVelocityKmPerSecond: 15
   }
 };
+
+const DEMO_ASTEROID_PREFIX = 'Demo Asteroid';
+const JOULES_PER_MEGATON_TNT = 4.184e15;
+let demoAsteroidCounter = 0;
+
+function randomBetween(min, max) {
+  return min + Math.random() * (max - min);
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function wrapDegrees(value) {
+  const raw = Number.isFinite(value) ? value : 0;
+  return ((raw % 360) + 360) % 360;
+}
+
+function estimateMeanMotionDegPerDay(semiMajorAxisAu) {
+  const axis = Math.max(semiMajorAxisAu, 0.2);
+  const earthMeanMotion = 0.9856076686;
+  const keplerFactor = 1 / Math.pow(axis, 1.5);
+  const variation = randomBetween(0.9, 1.1);
+  return clamp(earthMeanMotion * keplerFactor * variation, 0.05, 6);
+}
+
+function estimateTntYieldMegatons(diameterMeters) {
+  const radius = Math.max(diameterMeters, 20) / 2;
+  const density = 2800; // kg/m^3, typical stony asteroid
+  const volume = (4 / 3) * Math.PI * radius * radius * radius;
+  const mass = volume * density;
+  const velocity = 19_000; // m/s, representative impact velocity
+  const energyJoules = 0.5 * mass * velocity * velocity;
+  const megatons = energyJoules / JOULES_PER_MEGATON_TNT;
+  const rounded = Math.round(megatons * 10) / 10;
+  return clamp(rounded, 0, 50000);
+}
+
+function computeVisualScaleFromDiameter(diameterMeters) {
+  const normalized = clamp(diameterMeters / 1500, 0, 1);
+  return 0.025 + normalized * 0.075;
+}
+
+function computeAbsoluteMagnitude(diameterMeters, albedo) {
+  const safeDiameterKm = Math.max(diameterMeters / 1000, 0.01);
+  const safeAlbedo = clamp(albedo, 0.02, 0.6);
+  const base = 1329 / (safeDiameterKm * Math.sqrt(safeAlbedo));
+  const magnitude = 5 * Math.log10(base);
+  return clamp(magnitude, 12, 28);
+}
+
+function buildDemoAsteroidFeatures() {
+  const diameter = randomBetween(180, 1800);
+  const albedo = randomBetween(0.05, 0.35);
+  const semiMajorAxisAu = randomBetween(0.8, 2.6);
+  const eccentricity = randomBetween(0.05, 0.55);
+
+  const features = {
+    diameter,
+    diameter_sigma: diameter * randomBetween(0.04, 0.12),
+    e: eccentricity,
+    a: semiMajorAxisAu,
+    i: randomBetween(0, 35),
+    om: wrapDegrees(randomBetween(0, 360)),
+    w: wrapDegrees(randomBetween(0, 360)),
+    ma: wrapDegrees(randomBetween(0, 360)),
+    n: estimateMeanMotionDegPerDay(semiMajorAxisAu),
+    sigma_e: randomBetween(0.0002, 0.02),
+    sigma_a: randomBetween(0.0001, 0.01),
+    sigma_i: randomBetween(0.01, 0.4),
+    sigma_om: randomBetween(0.01, 1.2),
+    sigma_w: randomBetween(0.01, 1.2),
+    sigma_ma: randomBetween(0.01, 1.5),
+    sigma_n: randomBetween(0.0001, 0.01),
+    H_sigma: randomBetween(0.05, 0.3),
+    moid: randomBetween(0.02, 0.45)
+  };
+
+  features.H = computeAbsoluteMagnitude(diameter, albedo);
+
+  return features;
+}
+
+function createDemoAsteroidEntryFromFeatures(features, classification) {
+  const id = `demo-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  demoAsteroidCounter += 1;
+  const name = `${DEMO_ASTEROID_PREFIX} ${demoAsteroidCounter}`;
+
+  const meanMotionRadiansPerFrame = ((features.n ?? 0) * Math.PI) / 180 / FRAMES_PER_SIMULATION_DAY;
+  const orbit = {
+    semiMajorAxis: (features.a ?? 0) * AU_TO_SCENE_UNITS,
+    eccentricity: features.e ?? 0,
+    inclination: features.i ?? 0,
+    longitudeOfAscendingNode: features.om ?? 0,
+    argumentOfPeriapsis: features.w ?? 0,
+    meanAnomalyAtEpoch: features.ma ?? 0,
+    meanMotion: meanMotionRadiansPerFrame,
+    epoch: orbitTimeChannel?.getValue ? orbitTimeChannel.getValue() : 0
+  };
+
+  const entry = {
+    data: {
+      id,
+      name,
+      orbit,
+      visualScale: computeVisualScaleFromDiameter(features.diameter ?? 0),
+      tntYieldMt: estimateTntYieldMegatons(features.diameter ?? 0),
+      spinRate: randomBetween(0.0005, 0.0025),
+      isNeo: classification?.isNeo ?? null,
+      neoProbability: classification?.neoProbability ?? null,
+      isPhaHazardous: classification?.isPhaHazardous ?? null,
+      phaProbability: classification?.phaProbability ?? null,
+      demoFeatures: features
+    },
+    mesh: null,
+    keplerElements: createKeplerElements(orbit),
+    templateIndex: asteroidEntries.length,
+    earthOrbitIntersection: null
+  };
+
+  return entry;
+}
+
+function setAsteroidGeneratorStatus(message, tone = 'info') {
+  if (!asteroidGeneratorStatusElement) {
+    return;
+  }
+
+  asteroidGeneratorStatusElement.textContent = message ?? '';
+  asteroidGeneratorStatusElement.hidden = !message;
+  asteroidGeneratorStatusElement.classList.remove(
+    'asteroid-panel__status--error',
+    'asteroid-panel__status--success'
+  );
+
+  if (tone === 'error') {
+    asteroidGeneratorStatusElement.classList.add('asteroid-panel__status--error');
+  } else if (tone === 'success') {
+    asteroidGeneratorStatusElement.classList.add('asteroid-panel__status--success');
+  }
+}
+
+async function handleGenerateAsteroidClick() {
+  if (!asteroidGeneratorButton) {
+    return;
+  }
+
+  try {
+    asteroidGeneratorButton.disabled = true;
+    setAsteroidGeneratorStatus('Synthesising asteroid telemetry…');
+
+    await initializeAsteroids();
+
+    const features = buildDemoAsteroidFeatures();
+    const classification = await classifyAsteroid(features);
+    const entry = createDemoAsteroidEntryFromFeatures(features, classification);
+
+    asteroidEntries.push(entry);
+    asteroidEntryMap.set(entry.data.id, entry);
+    asteroidPanel?.addEntry(entry);
+    updateAsteroidPanelMetadata(entry);
+
+    const activationSucceeded = await activateAsteroid(entry);
+
+    if (!activationSucceeded) {
+      throw new Error('Unable to activate generated asteroid.');
+    }
+
+    const neoLabel = classification.isNeo ? 'NEO: Yes' : 'NEO: No';
+    const phaLabel = classification.isPhaHazardous ? 'PHA: Hazard' : 'PHA: Safe';
+    setAsteroidGeneratorStatus(`${entry.data.name} added · ${neoLabel} · ${phaLabel}`, 'success');
+  } catch (error) {
+    console.error('Failed to generate demo asteroid', error);
+    setAsteroidGeneratorStatus('Unable to generate demo asteroid. Please try again.', 'error');
+  } finally {
+    asteroidGeneratorButton.disabled = false;
+  }
+}
 
 const impactMapImage = new Image();
 impactMapImage.crossOrigin = 'anonymous';
@@ -1323,30 +1504,7 @@ function updateAsteroidPanelMetadata(entry) {
     return;
   }
 
-  const item = asteroidPanel.getItemElement(entry.data.id);
-  if (!item) {
-    return;
-  }
-
-  const metaElement = item.querySelector('.asteroid-panel__meta');
-  if (!metaElement) {
-    return;
-  }
-
-  const orbit = entry.data.orbit ?? {};
-  const yieldValue = entry.data.tntYieldMt;
-  const yieldText = Number.isFinite(yieldValue) ? yieldValue : 'N/A';
-  const semiMajorAxisText = Number.isFinite(orbit.semiMajorAxis)
-    ? orbit.semiMajorAxis.toFixed(1)
-    : 'N/A';
-  const eccentricityText = Number.isFinite(orbit.eccentricity)
-    ? orbit.eccentricity.toFixed(3)
-    : 'N/A';
-  const inclinationText = Number.isFinite(orbit.inclination)
-    ? orbit.inclination.toFixed(2)
-    : 'N/A';
-
-  metaElement.textContent = `Yield: ${yieldText} Mt | a=${semiMajorAxisText} | e=${eccentricityText} | i=${inclinationText}°`;
+  asteroidPanel.refreshEntry(entry);
 }
 const earthVelocityOrbital = new THREE.Vector3();
 const earthVelocityKilometersPerSecond = new THREE.Vector3();
@@ -2391,6 +2549,10 @@ if (impactorResetButton) {
 
 if (kineticMitigationButton) {
   kineticMitigationButton.addEventListener('click', handleKineticMitigation);
+}
+
+if (asteroidGeneratorButton) {
+  asteroidGeneratorButton.addEventListener('click', handleGenerateAsteroidClick);
 }
 
 requestAnimationFrame(animate);

--- a/src/model/neoClassifier.js
+++ b/src/model/neoClassifier.js
@@ -1,0 +1,101 @@
+import { InferenceSession, Tensor, env } from 'onnxruntime-web';
+import modelUrl from './astratek_model.onnx?url';
+
+const ORT_WEB_VERSION = '1.23.0'; // keep in sync with package.json
+
+env.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_WEB_VERSION}/dist/`;
+
+const FEATURE_ORDER = [
+  'diameter',
+  'diameter_sigma',
+  'e',
+  'a',
+  'i',
+  'om',
+  'w',
+  'ma',
+  'n',
+  'sigma_e',
+  'sigma_a',
+  'sigma_i',
+  'sigma_om',
+  'sigma_w',
+  'sigma_ma',
+  'sigma_n',
+  'H',
+  'H_sigma',
+  'moid'
+];
+
+let sessionPromise = null;
+
+async function getSession() {
+  if (!sessionPromise) {
+    sessionPromise = InferenceSession.create(modelUrl, {
+      executionProviders: ['wasm']
+    });
+  }
+
+  return sessionPromise;
+}
+
+function sigmoid(value) {
+  return 1 / (1 + Math.exp(-value));
+}
+
+function createInput(features) {
+  const data = new Float32Array(FEATURE_ORDER.length);
+  FEATURE_ORDER.forEach((name, index) => {
+    const rawValue = features?.[name];
+    data[index] = Number.isFinite(rawValue) ? rawValue : 0;
+  });
+
+  return new Tensor('float32', data, [1, data.length]);
+}
+
+function getFirstValue(mapLike) {
+  if (!mapLike) {
+    return null;
+  }
+
+  if (typeof mapLike.entries === 'function') {
+    const iterator = mapLike.entries();
+    const next = iterator.next();
+    if (!next.done) {
+      return next.value[1];
+    }
+  }
+
+  const keys = Object.keys(mapLike);
+  if (keys.length > 0) {
+    return mapLike[keys[0]];
+  }
+
+  return null;
+}
+
+async function classifyAsteroid(features) {
+  const session = await getSession();
+  const inputName = session.inputNames?.[0];
+  if (!inputName) {
+    throw new Error('ONNX model input name could not be resolved.');
+  }
+
+  const feeds = { [inputName]: createInput(features) };
+
+  const results = await session.run(feeds);
+  const output = getFirstValue(results);
+  const data = Array.from(output?.data ?? []);
+
+  const neoProbability = data.length > 0 ? sigmoid(data[0]) : 0;
+  const phaProbability = data.length > 1 ? sigmoid(data[1]) : 0;
+
+  return {
+    neoProbability,
+    phaProbability,
+    isNeo: neoProbability > 0.5,
+    isPhaHazardous: phaProbability > 0.5
+  };
+}
+
+export { classifyAsteroid, FEATURE_ORDER };

--- a/src/style.css
+++ b/src/style.css
@@ -103,9 +103,106 @@ p {
     font-weight: 600;
 }
 
+.asteroid-panel__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.asteroid-panel__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: flex-end;
+}
+
 .asteroid-panel__meta {
     font-size: 12px;
     color: #c0d7ff;
+}
+
+.asteroid-panel__actions {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.asteroid-panel__button {
+    padding: 8px 10px;
+    border: 1px solid rgba(158, 203, 255, 0.4);
+    border-radius: 6px;
+    background: linear-gradient(135deg, rgba(88, 140, 220, 0.65), rgba(40, 80, 160, 0.9));
+    color: #f8faff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.asteroid-panel__button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(46, 100, 190, 0.35);
+}
+
+.asteroid-panel__button:disabled {
+    opacity: 0.6;
+    cursor: wait;
+}
+
+.asteroid-panel__hint {
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #9fb9ff;
+}
+
+.asteroid-panel__status {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: #b8d2ff;
+}
+
+.asteroid-panel__status--error {
+    color: #ff8b8b;
+}
+
+.asteroid-panel__status--success {
+    color: #9affc6;
+}
+
+.asteroid-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 6px;
+    border-radius: 12px;
+    font-size: 10px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    background: rgba(255, 255, 255, 0.12);
+    color: #f4f7ff;
+}
+
+.asteroid-badge--positive {
+    background: rgba(100, 220, 180, 0.25);
+    color: #b9ffe7;
+}
+
+.asteroid-badge--hazard {
+    background: rgba(230, 90, 90, 0.35);
+    color: #ffd5d5;
+}
+
+.asteroid-badge--neutral {
+    background: rgba(90, 120, 160, 0.35);
+    color: #d4e2ff;
+}
+
+.asteroid-badge--unknown {
+    background: rgba(255, 255, 255, 0.1);
+    color: #e4e7ff;
 }
 
 .impact-legend {

--- a/src/ui/asteroidPanel.js
+++ b/src/ui/asteroidPanel.js
@@ -1,3 +1,120 @@
+function createBadge({ label, value, probability, positiveLabel, negativeLabel, tonePositive, toneNegative }) {
+  const badge = document.createElement('span');
+  badge.className = 'asteroid-badge';
+
+  let toneClass = 'asteroid-badge--unknown';
+  let valueLabel = 'Unknown';
+
+  if (value === true) {
+    toneClass = tonePositive ?? 'asteroid-badge--positive';
+    valueLabel = positiveLabel ?? 'Yes';
+  } else if (value === false) {
+    toneClass = toneNegative ?? 'asteroid-badge--neutral';
+    valueLabel = negativeLabel ?? 'No';
+  }
+
+  if (toneClass) {
+    badge.classList.add(toneClass);
+  }
+
+  const probabilityText = Number.isFinite(probability)
+    ? ` (${Math.round(probability * 100)}%)`
+    : '';
+
+  badge.textContent = `${label} · ${valueLabel}${probabilityText}`;
+  return badge;
+}
+
+function renderClassification(container, data = {}) {
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+
+  const neoBadge = createBadge({
+    label: 'NEO',
+    value: data.isNeo,
+    probability: data.neoProbability,
+    positiveLabel: 'Yes',
+    negativeLabel: 'No',
+    tonePositive: 'asteroid-badge--positive',
+    toneNegative: 'asteroid-badge--neutral'
+  });
+
+  const phaBadge = createBadge({
+    label: 'PHA',
+    value: data.isPhaHazardous,
+    probability: data.phaProbability,
+    positiveLabel: 'Hazard',
+    negativeLabel: 'Safe',
+    tonePositive: 'asteroid-badge--hazard',
+    toneNegative: 'asteroid-badge--neutral'
+  });
+
+  container.appendChild(neoBadge);
+  container.appendChild(phaBadge);
+}
+
+function setMetaText(metaElement, data) {
+  if (!metaElement) {
+    return;
+  }
+
+  const orbit = data.orbit ?? {};
+  const yieldText = Number.isFinite(data.tntYieldMt) ? data.tntYieldMt : 'N/A';
+  const semiMajorAxisText = Number.isFinite(orbit.semiMajorAxis)
+    ? orbit.semiMajorAxis.toFixed(1)
+    : 'N/A';
+  const eccentricityText = Number.isFinite(orbit.eccentricity)
+    ? orbit.eccentricity.toFixed(3)
+    : 'N/A';
+  const inclinationText = Number.isFinite(orbit.inclination)
+    ? orbit.inclination.toFixed(2)
+    : 'N/A';
+
+  metaElement.textContent = `Yield: ${yieldText} Mt | a=${semiMajorAxisText} | e=${eccentricityText} | i=${inclinationText}°`;
+}
+
+function createListItem(entry, { onToggle }) {
+  const { data } = entry;
+  const item = document.createElement('li');
+  item.className = 'asteroid-panel__item';
+  item.dataset.asteroidId = data.id;
+
+  const headerRow = document.createElement('div');
+  headerRow.className = 'asteroid-panel__row';
+
+  const nameElement = document.createElement('span');
+  nameElement.className = 'asteroid-panel__name';
+  nameElement.textContent = data.name;
+
+  const badgesContainer = document.createElement('div');
+  badgesContainer.className = 'asteroid-panel__badges';
+
+  headerRow.appendChild(nameElement);
+  headerRow.appendChild(badgesContainer);
+
+  const metaElement = document.createElement('span');
+  metaElement.className = 'asteroid-panel__meta';
+
+  item.appendChild(headerRow);
+  item.appendChild(metaElement);
+
+  item.addEventListener('click', () => {
+    const isActive = item.classList.contains('asteroid-panel__item--active');
+    const nextState = !isActive;
+    if (typeof onToggle === 'function') {
+      onToggle(data.id, nextState);
+    }
+  });
+
+  setMetaText(metaElement, data);
+  renderClassification(badgesContainer, data);
+
+  return item;
+}
+
 function initAsteroidPanel(entries, { onToggle } = {}) {
   const listElement = document.getElementById('asteroidList');
   const panelElement = document.getElementById('asteroidListPanel');
@@ -18,34 +135,9 @@ function initAsteroidPanel(entries, { onToggle } = {}) {
     listElement.innerHTML = '';
 
     entries.forEach(entry => {
-      const { data } = entry;
-      const orbit = data.orbit ?? {};
-      const yieldText = Number.isFinite(data.tntYieldMt) ? data.tntYieldMt : 'N/A';
-      const semiMajorAxisText = Number.isFinite(orbit.semiMajorAxis)
-        ? orbit.semiMajorAxis.toFixed(1)
-        : 'N/A';
-      const eccentricityText = Number.isFinite(orbit.eccentricity)
-        ? orbit.eccentricity.toFixed(3)
-        : 'N/A';
-      const inclinationText = Number.isFinite(orbit.inclination)
-        ? orbit.inclination.toFixed(2)
-        : 'N/A';
-      const item = document.createElement('li');
-      item.className = 'asteroid-panel__item';
-      item.dataset.asteroidId = data.id;
-      item.innerHTML =
-        `<span class='asteroid-panel__name'>${data.name}</span>` +
-        `<span class='asteroid-panel__meta'>Yield: ${yieldText} Mt | a=${semiMajorAxisText} | e=${eccentricityText} | i=${inclinationText}°</span>`;
-      item.addEventListener('click', () => {
-        const isActive = activeIds.has(data.id);
-        const nextState = !isActive;
-        if (typeof onToggle === 'function') {
-          onToggle(data.id, nextState);
-        }
-      });
-
+      const item = createListItem(entry, { onToggle });
       listElement.appendChild(item);
-      itemMap.set(data.id, item);
+      itemMap.set(entry.data.id, item);
     });
   }
 
@@ -106,7 +198,33 @@ function initAsteroidPanel(entries, { onToggle } = {}) {
     setTracked,
     setFocused,
     clearFocus,
-    getItemElement
+    getItemElement,
+    addEntry(entry) {
+      if (!listElement || !entry?.data?.id) {
+        return;
+      }
+
+      const item = createListItem(entry, { onToggle });
+      listElement.appendChild(item);
+      itemMap.set(entry.data.id, item);
+    },
+    refreshEntry(entry) {
+      const item = entry?.data?.id ? itemMap.get(entry.data.id) : null;
+      if (!item) {
+        return;
+      }
+
+      const badgesContainer = item.querySelector('.asteroid-panel__badges');
+      const metaElement = item.querySelector('.asteroid-panel__meta');
+      const nameElement = item.querySelector('.asteroid-panel__name');
+
+      if (nameElement) {
+        nameElement.textContent = entry.data.name ?? entry.data.id;
+      }
+
+      setMetaText(metaElement, entry.data);
+      renderClassification(badgesContainer, entry.data);
+    }
   };
 }
 

--- a/static/onnx/README.md
+++ b/static/onnx/README.md
@@ -1,0 +1,6 @@
+# ONNX Runtime WASM Assets
+
+The client now loads WebAssembly binaries for `onnxruntime-web` directly from jsDelivr. No local `.wasm`
+artifacts are committed to the repository so downstream contributors do not need to stage large binary
+assets when opening pull requests. If the CDN location ever changes, update the path configured in
+`src/model/neoClassifier.js`.


### PR DESCRIPTION
## Summary
- remove the bundled onnxruntime-web wasm binaries so the repo no longer includes large binary artifacts
- configure the classifier to pull the wasm runtime from the jsDelivr CDN using the package version
- document the CDN-based loading approach in the onnx asset readme

## Testing
- npm run build *(fails: `vite: Permission denied` in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e277d545bc8322b16d996bde207d7b